### PR TITLE
api url change

### DIFF
--- a/R/process-error.R
+++ b/R/process-error.R
@@ -22,7 +22,7 @@ throw_if_loc_error <- function(resp) {
 #' @noRd
 hit_locations_ep <- function(url) {
   grepl(
-    "^http://www.patentsview.org/api/locations/",
+    "^https://api.patentsview.org/locations/",
     url,
     ignore.case = TRUE
   )

--- a/R/search-pv.R
+++ b/R/search-pv.R
@@ -1,6 +1,6 @@
 #' @noRd
 get_base <- function(endpoint)
-  sprintf("https://www.patentsview.org/api/%s/query", endpoint)
+  sprintf("https://api.patentsview.org/%s/query", endpoint)
 
 #' @noRd
 tojson_2 <- function(x, ...) {


### PR DESCRIPTION
My guess in https://github.com/ropensci/patentsview/issues/21#issuecomment-687624142 seems to be right.  This [stack overflow answer](https://stackoverflow.com/a/13628908) says that the body is not sent on a 301 redirect.  With these api url changes the R code doing a post in https://github.com/ropensci/patentsview/issues/21#issuecomment-687624142 works.